### PR TITLE
Set perms on pre-merge actions

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -1,4 +1,7 @@
 name: 'Check inbound changes'
+permissions:
+  contents: read
+  pull-requests: write
 
 # Triggers
 on: [push, workflow_dispatch]


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change adds explicit permissions for reading repository contents and writing to pull requests, which helps clarify and restrict the workflow's access.

* Added `permissions` block to `.github/workflows/premerge.yaml` to specify `contents: read` and `pull-requests: write`.