### PR TITLE
Phue to requests

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -3,7 +3,7 @@ permissions:
   contents: read
 
 # Triggers
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 # Jobs
 jobs:

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -1,7 +1,6 @@
 name: 'Check inbound changes'
 permissions:
   contents: read
-  pull-requests: write
 
 # Triggers
 on: [push, workflow_dispatch]

--- a/huetoinflux.py
+++ b/huetoinflux.py
@@ -5,10 +5,8 @@ import sys
 import time
 import json
 import signal
-import socket
 import argparse
 import requests
-import phue
 
 # load the settings.json file
 try:
@@ -44,10 +42,13 @@ def get_data_from_bridge():
     :rtype: dict
     """
     try:
-        hue = phue.Bridge(ip=settings["hue"]["host"], username=settings["hue"]["user"])
-        hue.connect()
-        hue_data = hue.get_api()
-    except (socket.gaierror, ConnectionRefusedError, phue.PhueRequestTimeout) as e:
+        response = requests.get(
+            f"https://{settings['hue']['host']}/api/{settings['hue']['user']}",
+            timeout=settings["hue"].get("timeout", 5),
+            verify=False,
+        )
+        hue_data = response.json()
+    except requests.exceptions.RequestException as e:
         print(f"Error connecting to Hue Bridge - {e}")
         sys.exit(2)
     if isinstance(hue_data, list) and "error" in hue_data[0]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ flake8~=7.1.1
 flake8-bugbear~=24.10.31
 flake8-black~=0.3.6
 black~=24.4.2
-phue~=1.1
 requests~=2.32.3

--- a/settings.json.example
+++ b/settings.json.example
@@ -2,6 +2,7 @@
   "hue": {
     "host": "hue.example.com",
     "user": "your_hue_user"
+    "timeout": 5
   },
   "influx": {
     "url": "https://influx.example.com:8086",


### PR DESCRIPTION
This pull request updates the way data is retrieved from the Hue Bridge by removing the dependency on the `phue` library and using direct HTTPS requests instead. It also updates the workflow to trigger on pull requests and adds a configurable timeout to the Hue settings.

**Hue Bridge integration changes:**
* Replaced the use of the `phue` library with direct HTTPS requests via the `requests` library in the `get_data_from_bridge` function, improving compatibility and reducing dependencies.
* Removed imports of `phue` and `socket` since they are no longer needed.

**Configuration improvements:**
* Added a `timeout` parameter to the `hue` section in `settings.json.example` to allow configuration of request timeouts.

**CI workflow update:**
* Modified the `.github/workflows/premerge.yaml` workflow to also trigger on pull requests, ensuring checks run for inbound PRs.