### PR TITLE
Add missing comma in example json

### DIFF
--- a/settings.json.example
+++ b/settings.json.example
@@ -1,7 +1,7 @@
 {
   "hue": {
     "host": "hue.example.com",
-    "user": "your_hue_user"
+    "user": "your_hue_user",
     "timeout": 5
   },
   "influx": {


### PR DESCRIPTION
This pull request makes a minor update to the `settings.json.example` configuration file by adding a new `timeout` parameter to the `hue` settings section. This change allows users to specify a timeout value for the Hue service connection.