### PR TITLE
Add deprication notice to README.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ HueToInflux
 
 [DEPRECATED] - See https://github.com/GavinLucas/send-to-influx instead
 
-Moving development into a new repo that abstracts the data collextion and therefore combines the functionality of several independent repos, this one included.
+Moving development into a new repo that abstracts the data collection and therefore combines the functionality of several independent repos, this one included.
 
 https://github.com/GavinLucas/HueToInflux
 -----------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 HueToInflux
 ===========
 
+[DEPRECATED] - See https://github.com/GavinLucas/send-to-influx instead
+
+Moving development into a new repo that abstracts the data collextion and therefore combines the functionality of several independent repos, this one included.
+
 https://github.com/GavinLucas/HueToInflux
 -----------------------------------------
 


### PR DESCRIPTION
This pull request updates the `README.md` file to indicate that the `HueToInflux` project is now deprecated. It directs users to a new repository that consolidates functionality from multiple projects.

Project deprecation and migration notice:

* Added a deprecation notice to the top of the `README.md`, pointing users to the new repository `send-to-influx` and explaining the motivation for the migration.